### PR TITLE
Return EOF from PcapReader::next if last refill failed

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -248,7 +248,7 @@ impl<'a> ToVec for NameResolutionBlock<'a> {
         self.block_type = NRB_MAGIC;
         // fix length
         let length = (12 + namerecords_length(&self.nr) + self.opt.len()) as u32;
-        self.block_len1 = align32!(length);;
+        self.block_len1 = align32!(length);
         self.block_len2 = self.block_len1;
     }
 


### PR DESCRIPTION
This fixes #3 in a backwards compatible way. I'm not sure if this is the way to go though.

A simpler fix would return `Err(PcapParser::Eof)` from the `refill` methods if the reader didn't return anything. This could break existing usages of the library though.

Let me know which approach you prefer and I'll update the PR :)