### PR TITLE
Don't make trait PcapReadIterator generic over R

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -33,7 +33,7 @@ pub trait Capture {
 pub fn create_reader<'b, R>(
     capacity: usize,
     mut reader: R,
-) -> Result<Box<dyn PcapReaderIterator<R> + 'b>, PcapError>
+) -> Result<Box<dyn PcapReaderIterator + 'b>, PcapError>
 where
     R: Read + 'b,
 {
@@ -46,11 +46,11 @@ where
     // just check that first block is a valid one
     if parse_sectionheaderblock(buffer.data()).is_ok() {
         return PcapNGReader::from_buffer(buffer, reader)
-            .map(|r| Box::new(r) as Box<dyn PcapReaderIterator<R>>);
+            .map(|r| Box::new(r) as Box<dyn PcapReaderIterator>);
     }
     match parse_pcap_header(buffer.data()) {
         Ok(_) => LegacyPcapReader::from_buffer(buffer, reader)
-            .map(|r| Box::new(r) as Box<dyn PcapReaderIterator<R>>),
+            .map(|r| Box::new(r) as Box<dyn PcapReaderIterator>),
         Err(nom::Err::Incomplete(_)) => Err(PcapError::Incomplete),
         _ => Err(PcapError::HeaderNotRecognized),
     }

--- a/src/capture_pcap.rs
+++ b/src/capture_pcap.rs
@@ -131,7 +131,7 @@ where
     }
 }
 
-impl<R> PcapReaderIterator<R> for LegacyPcapReader<R>
+impl<R> PcapReaderIterator for LegacyPcapReader<R>
 where
     R: Read,
 {

--- a/src/capture_pcapng.rs
+++ b/src/capture_pcapng.rs
@@ -140,7 +140,7 @@ where
     }
 }
 
-impl<R> PcapReaderIterator<R> for PcapNGReader<R>
+impl<R> PcapReaderIterator for PcapNGReader<R>
 where
     R: Read,
 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,7 +2,6 @@ use crate::blocks::PcapBlockOwned;
 use crate::error::PcapError;
 use crate::read_u32_e;
 use rusticata_macros::align32;
-use std::io::Read;
 
 /// Common methods for PcapNG blocks
 pub trait PcapNGBlock {
@@ -76,9 +75,7 @@ pub trait PcapNGBlock {
 /// **The blocks already read, and underlying data, must be discarded before calling
 /// `consume` or `refill`.** It is the caller's responsibility to call functions in the correct
 /// order.
-pub trait PcapReaderIterator<R>
-where
-    R: Read,
+pub trait PcapReaderIterator
 {
     /// Get the next pcap block, if possible. Returns the number of bytes read and the block.
     fn next(&mut self) -> Result<(usize, PcapBlockOwned), PcapError>;


### PR DESCRIPTION
R is not used in PcapReadIterator and having the trait generic over R complicates using the Boxes returned from create_reader()

Removing R makes something like this possible:
<pre>
let file = File::open(path)?;
let mut reader = match pcap_parser::create_reader(4096, file) {
    Ok(reader) => reader,
    Err(PcapError::HeaderNotRecognized) => {
        // Try gzip
	let file = File::open(path)?;
        let mut gz = GzDecoder::new(file);
        pcap_parser::create_reader(4096, gz)?
    },
    Err(e) => bail!(e),
};
</pre>

I think this would be a breaking change and I'm not sure if I missed any use case that needs this parameter.
cargo build && cargo test run fine and I'm able to read pcap, pcapng and gzipped pcaps now.

Thanks for your work on pcap-parser and let me know if I should change anything.