### PR TITLE
Dev/generic errors v0.1

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -33,7 +33,7 @@ pub trait Capture {
 pub fn create_reader<'b, R>(
     capacity: usize,
     mut reader: R,
-) -> Result<Box<dyn PcapReaderIterator + 'b>, PcapError>
+) -> Result<Box<dyn PcapReaderIterator + 'b>, PcapError<&'static [u8]>>
 where
     R: Read + 'b,
 {

--- a/src/capture_pcap.rs
+++ b/src/capture_pcap.rs
@@ -132,7 +132,11 @@ where
                 PcapBlockOwned::from(self.header.clone()),
             ));
         }
-        if self.buffer.position() == 0 && self.buffer.available_data() == 0 || self.reader_exhausted
+        // Return EOF if
+        // 1) all bytes have been read
+        // 2) no more data is available
+        if self.buffer.available_data() == 0
+            && (self.buffer.position() == 0 || self.reader_exhausted)
         {
             return Err(PcapError::Eof);
         }

--- a/src/capture_pcap.rs
+++ b/src/capture_pcap.rs
@@ -75,6 +75,7 @@ where
     header: PcapHeader,
     reader: R,
     buffer: Buffer,
+    consumed: usize,
     header_sent: bool,
     reader_exhausted: bool,
     parse: LegacyParseFn,
@@ -116,6 +117,7 @@ where
             header,
             reader,
             buffer,
+            consumed: 0,
             header_sent: false,
             reader_exhausted: false,
             parse,
@@ -154,10 +156,15 @@ where
         }
     }
     fn consume(&mut self, offset: usize) {
+        self.consumed += offset;
         self.buffer.consume(offset);
     }
     fn consume_noshift(&mut self, offset: usize) {
+        self.consumed += offset;
         self.buffer.consume_noshift(offset);
+    }
+    fn consumed(&self) -> usize {
+        self.consumed
     }
     fn refill(&mut self) -> Result<(), PcapError<&[u8]>> {
         self.buffer.shift();

--- a/src/capture_pcapng.rs
+++ b/src/capture_pcapng.rs
@@ -138,7 +138,11 @@ where
     R: Read,
 {
     fn next(&mut self) -> Result<(usize, PcapBlockOwned), PcapError> {
-        if self.buffer.position() == 0 && self.buffer.available_data() == 0 || self.reader_exhausted
+        // Return EOF if
+        // 1) all bytes have been read
+        // 2) no more data is available
+        if self.buffer.available_data() == 0
+            && (self.buffer.position() == 0 || self.reader_exhausted)
         {
             return Err(PcapError::Eof);
         }

--- a/src/capture_pcapng.rs
+++ b/src/capture_pcapng.rs
@@ -100,6 +100,7 @@ where
     info: CurrentSectionInfo,
     reader: R,
     buffer: Buffer,
+    consumed: usize,
     reader_exhausted: bool,
 }
 
@@ -131,6 +132,7 @@ where
             info,
             reader,
             buffer,
+            consumed: 0,
             reader_exhausted: false,
         })
     }
@@ -168,10 +170,15 @@ where
         }
     }
     fn consume(&mut self, offset: usize) {
+        self.consumed += offset;
         self.buffer.consume(offset);
     }
     fn consume_noshift(&mut self, offset: usize) {
+        self.consumed += offset;
         self.buffer.consume_noshift(offset);
+    }
+    fn consumed(&self) -> usize {
+        self.consumed
     }
     fn refill(&mut self) -> Result<(), PcapError<&[u8]>> {
         self.buffer.shift();

--- a/src/data/pcap_nflog.rs
+++ b/src/data/pcap_nflog.rs
@@ -129,14 +129,10 @@ pub fn get_packetdata_nflog(i: &[u8], _caplen: usize) -> Option<PacketData> {
                 10 => ETHERTYPE_IPV6,
                 _ => 0,
             };
-            match res
-                .data
+            res.data
                 .into_iter()
                 .find(|v| v.t == NfAttrType::Payload as u16)
-            {
-                Some(v) => Some(PacketData::L3(ethertype, v.v)),
-                None => None,
-            }
+                .map(|tlv| PacketData::L3(ethertype, tlv.v))
         }
         _ => None,
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,37 +1,65 @@
 use nom::error::{ErrorKind, ParseError};
-use std::error::Error;
 use std::fmt;
 
 #[derive(Debug, PartialEq)]
-pub enum PcapError {
+pub enum PcapError<I: Sized> {
     Eof,
     ReadError,
     Incomplete,
 
     HeaderNotRecognized,
 
-    NomError(ErrorKind),
+    NomError(I, ErrorKind),
+    OwnedNomError(Vec<u8>, ErrorKind),
 }
 
-impl<I> ParseError<I> for PcapError {
-    fn from_error_kind(_input: I, kind: ErrorKind) -> Self {
-        PcapError::NomError(kind)
+impl<I> PcapError<I>
+where
+    I: AsRef<[u8]> + Sized,
+{
+    pub fn to_owned_vec(&self) -> PcapError<&'static [u8]> {
+        match self {
+            PcapError::Eof => PcapError::Eof,
+            PcapError::ReadError => PcapError::ReadError,
+            PcapError::Incomplete => PcapError::Incomplete,
+            PcapError::HeaderNotRecognized => PcapError::HeaderNotRecognized,
+            PcapError::NomError(i, errorkind) => {
+                PcapError::OwnedNomError(i.as_ref().to_vec(), *errorkind)
+            }
+            PcapError::OwnedNomError(v, e) => PcapError::OwnedNomError(v.clone(), *e),
+        }
     }
-    fn append(_input: I, kind: ErrorKind, _other: Self) -> Self {
-        PcapError::NomError(kind)
+
+    pub fn from_data(input: I, errorkind: ErrorKind) -> Self {
+        Self::NomError(input, errorkind)
     }
 }
 
-impl fmt::Display for PcapError {
+impl<I> ParseError<I> for PcapError<I> {
+    fn from_error_kind(input: I, kind: ErrorKind) -> Self {
+        PcapError::NomError(input, kind)
+    }
+    fn append(input: I, kind: ErrorKind, _other: Self) -> Self {
+        PcapError::NomError(input, kind)
+    }
+}
+
+impl<I> fmt::Display for PcapError<I>
+where
+    I: std::fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PcapError::Eof => write!(f, "End of file"),
             PcapError::ReadError => write!(f, "Read error"),
             PcapError::Incomplete => write!(f, "Incomplete read"),
             PcapError::HeaderNotRecognized => write!(f, "Header not recognized as PCAP or PCAPNG"),
-            PcapError::NomError(e) => write!(f, "Internal parser error {:?}", e),
+            PcapError::NomError(i, e) => write!(f, "Internal parser error {:?}, input {:?}", e, i),
+            PcapError::OwnedNomError(i, e) => {
+                write!(f, "Internal parser error {:?}, input {:?}", e, &i)
+            }
         }
     }
 }
 
-impl Error for PcapError {}
+impl<I> std::error::Error for PcapError<I> where I: std::fmt::Debug {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,38 @@
 use nom::error::{ErrorKind, ParseError};
 use std::fmt;
 
+/// The error type which is returned when reading a pcap file
 #[derive(Debug, PartialEq)]
 pub enum PcapError<I: Sized> {
+    /// No more data available
     Eof,
+    /// An error happened during a `read` operation
     ReadError,
+    /// Last block is incomplete, and no more data available
     Incomplete,
 
+    /// File could not be recognized as Pcap nor Pcap-NG
     HeaderNotRecognized,
 
+    /// An error encountered during parsing
     NomError(I, ErrorKind),
+    /// An error encountered during parsing (owned version)
     OwnedNomError(Vec<u8>, ErrorKind),
+}
+
+impl<I> PcapError<I> {
+    /// Creates a `PcapError` from input and error kind.
+    pub fn from_data(input: I, errorkind: ErrorKind) -> Self {
+        Self::NomError(input, errorkind)
+    }
 }
 
 impl<I> PcapError<I>
 where
     I: AsRef<[u8]> + Sized,
 {
+    /// Creates an owned `PcapError` object from borrowed data, cloning object.
+    /// Owned object has `'static` lifetime.
     pub fn to_owned_vec(&self) -> PcapError<&'static [u8]> {
         match self {
             PcapError::Eof => PcapError::Eof,
@@ -28,10 +44,6 @@ where
             }
             PcapError::OwnedNomError(v, e) => PcapError::OwnedNomError(v.clone(), *e),
         }
-    }
-
-    pub fn from_data(input: I, errorkind: ErrorKind) -> Self {
-        Self::NomError(input, errorkind)
     }
 }
 

--- a/src/pcap.rs
+++ b/src/pcap.rs
@@ -89,7 +89,7 @@ pub struct LegacyPcapBlock<'a> {
 ///
 /// Each PCAP record starts with a small header, and is followed by packet data.
 /// The packet data format depends on the LinkType.
-pub fn parse_pcap_frame(i: &[u8]) -> IResult<&[u8], LegacyPcapBlock, PcapError> {
+pub fn parse_pcap_frame(i: &[u8]) -> IResult<&[u8], LegacyPcapBlock, PcapError<&[u8]>> {
     if i.len() < 16 {
         return Err(nom::Err::Incomplete(nom::Needed::new(16)));
     }
@@ -112,7 +112,7 @@ pub fn parse_pcap_frame(i: &[u8]) -> IResult<&[u8], LegacyPcapBlock, PcapError> 
 ///
 /// Each PCAP record starts with a small header, and is followed by packet data.
 /// The packet data format depends on the LinkType.
-pub fn parse_pcap_frame_be(i: &[u8]) -> IResult<&[u8], LegacyPcapBlock, PcapError> {
+pub fn parse_pcap_frame_be(i: &[u8]) -> IResult<&[u8], LegacyPcapBlock, PcapError<&[u8]>> {
     if i.len() < 16 {
         return Err(nom::Err::Incomplete(nom::Needed::new(16)));
     }
@@ -134,7 +134,7 @@ pub fn parse_pcap_frame_be(i: &[u8]) -> IResult<&[u8], LegacyPcapBlock, PcapErro
 /// Read the PCAP global header
 ///
 /// The global header contains the PCAP description and options
-pub fn parse_pcap_header(i: &[u8]) -> IResult<&[u8], PcapHeader, PcapError> {
+pub fn parse_pcap_header(i: &[u8]) -> IResult<&[u8], PcapHeader, PcapError<&[u8]>> {
     let (i, magic_number) = le_u32(i)?;
     match magic_number {
         0xa1b2_c3d4 | 0xa1b2_3c4d => {

--- a/src/pcapng.rs
+++ b/src/pcapng.rs
@@ -967,16 +967,20 @@ pub(crate) fn opt_parse_options<'i, En: PcapEndianness, E: ParseError<&'i [u8]>>
     }
 }
 
-pub fn parse_sectionheaderblock_le(i: &[u8]) -> IResult<&[u8], SectionHeaderBlock, PcapError> {
+pub fn parse_sectionheaderblock_le(
+    i: &[u8],
+) -> IResult<&[u8], SectionHeaderBlock, PcapError<&[u8]>> {
     ng_block_parser::<SectionHeaderBlock, PcapLE, _, _>()(i)
 }
 
-pub fn parse_sectionheaderblock_be(i: &[u8]) -> IResult<&[u8], SectionHeaderBlock, PcapError> {
+pub fn parse_sectionheaderblock_be(
+    i: &[u8],
+) -> IResult<&[u8], SectionHeaderBlock, PcapError<&[u8]>> {
     ng_block_parser::<SectionHeaderBlock, PcapBE, _, _>()(i)
 }
 
 /// Parse a SectionHeaderBlock (little or big endian)
-pub fn parse_sectionheaderblock(i: &[u8]) -> IResult<&[u8], SectionHeaderBlock, PcapError> {
+pub fn parse_sectionheaderblock(i: &[u8]) -> IResult<&[u8], SectionHeaderBlock, PcapError<&[u8]>> {
     if i.len() < 12 {
         return Err(nom::Err::Incomplete(nom::Needed::new(12)));
     }
@@ -996,7 +1000,7 @@ pub fn parse_sectionheaderblock(i: &[u8]) -> IResult<&[u8], SectionHeaderBlock, 
     note = "Please use the parse_sectionheaderblock function instead"
 )]
 #[inline]
-pub fn parse_sectionheader(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
+pub fn parse_sectionheader(i: &[u8]) -> IResult<&[u8], Block, PcapError<&[u8]>> {
     parse_sectionheaderblock(i).map(|(r, b)| (r, Block::SectionHeader(b)))
 }
 
@@ -1026,14 +1030,14 @@ fn if_extract_tsoffset_and_tsresol(options: &[PcapNGOption]) -> (u8, u64) {
 /// Parse an Interface Packet Block (little-endian)
 pub fn parse_interfacedescriptionblock_le(
     i: &[u8],
-) -> IResult<&[u8], InterfaceDescriptionBlock, PcapError> {
+) -> IResult<&[u8], InterfaceDescriptionBlock, PcapError<&[u8]>> {
     ng_block_parser::<InterfaceDescriptionBlock, PcapLE, _, _>()(i)
 }
 
 /// Parse an Interface Packet Block (big-endian)
 pub fn parse_interfacedescriptionblock_be(
     i: &[u8],
-) -> IResult<&[u8], InterfaceDescriptionBlock, PcapError> {
+) -> IResult<&[u8], InterfaceDescriptionBlock, PcapError<&[u8]>> {
     ng_block_parser::<InterfaceDescriptionBlock, PcapBE, _, _>()(i)
 }
 
@@ -1041,24 +1045,28 @@ pub fn parse_interfacedescriptionblock_be(
 ///
 /// *Note: this function does not remove padding in the `data` field.
 /// Use `packet_data` to get field without padding.*
-pub fn parse_simplepacketblock_le(i: &[u8]) -> IResult<&[u8], SimplePacketBlock, PcapError> {
+pub fn parse_simplepacketblock_le(i: &[u8]) -> IResult<&[u8], SimplePacketBlock, PcapError<&[u8]>> {
     ng_block_parser::<SimplePacketBlock, PcapLE, _, _>()(i)
 }
 
 /// Parse a Simple Packet Block (big-endian)
 ///
 /// *Note: this function does not remove padding*
-pub fn parse_simplepacketblock_be(i: &[u8]) -> IResult<&[u8], SimplePacketBlock, PcapError> {
+pub fn parse_simplepacketblock_be(i: &[u8]) -> IResult<&[u8], SimplePacketBlock, PcapError<&[u8]>> {
     ng_block_parser::<SimplePacketBlock, PcapBE, _, _>()(i)
 }
 
 /// Parse an Enhanced Packet Block (little-endian)
-pub fn parse_enhancedpacketblock_le(i: &[u8]) -> IResult<&[u8], EnhancedPacketBlock, PcapError> {
+pub fn parse_enhancedpacketblock_le(
+    i: &[u8],
+) -> IResult<&[u8], EnhancedPacketBlock, PcapError<&[u8]>> {
     ng_block_parser::<EnhancedPacketBlock, PcapLE, _, _>()(i)
 }
 
 /// Parse an Enhanced Packet Block (big-endian)
-pub fn parse_enhancedpacketblock_be(i: &[u8]) -> IResult<&[u8], EnhancedPacketBlock, PcapError> {
+pub fn parse_enhancedpacketblock_be(
+    i: &[u8],
+) -> IResult<&[u8], EnhancedPacketBlock, PcapError<&[u8]>> {
     ng_block_parser::<EnhancedPacketBlock, PcapBE, _, _>()(i)
 }
 
@@ -1089,82 +1097,86 @@ fn parse_name_record_list<'a, En: PcapEndianness, E: ParseError<&'a [u8]>>(
 }
 
 #[inline]
-pub fn parse_nameresolutionblock_le(i: &[u8]) -> IResult<&[u8], NameResolutionBlock, PcapError> {
+pub fn parse_nameresolutionblock_le(
+    i: &[u8],
+) -> IResult<&[u8], NameResolutionBlock, PcapError<&[u8]>> {
     ng_block_parser::<NameResolutionBlock, PcapLE, _, _>()(i)
 }
 
 #[inline]
-pub fn parse_nameresolutionblock_be(i: &[u8]) -> IResult<&[u8], NameResolutionBlock, PcapError> {
+pub fn parse_nameresolutionblock_be(
+    i: &[u8],
+) -> IResult<&[u8], NameResolutionBlock, PcapError<&[u8]>> {
     ng_block_parser::<NameResolutionBlock, PcapBE, _, _>()(i)
 }
 
 pub fn parse_interfacestatisticsblock_le(
     i: &[u8],
-) -> IResult<&[u8], InterfaceStatisticsBlock, PcapError> {
+) -> IResult<&[u8], InterfaceStatisticsBlock, PcapError<&[u8]>> {
     ng_block_parser::<InterfaceStatisticsBlock, PcapLE, _, _>()(i)
 }
 
 pub fn parse_interfacestatisticsblock_be(
     i: &[u8],
-) -> IResult<&[u8], InterfaceStatisticsBlock, PcapError> {
+) -> IResult<&[u8], InterfaceStatisticsBlock, PcapError<&[u8]>> {
     ng_block_parser::<InterfaceStatisticsBlock, PcapBE, _, _>()(i)
 }
 
 #[inline]
 pub fn parse_systemdjournalexportblock_le(
     i: &[u8],
-) -> IResult<&[u8], SystemdJournalExportBlock, PcapError> {
+) -> IResult<&[u8], SystemdJournalExportBlock, PcapError<&[u8]>> {
     ng_block_parser::<SystemdJournalExportBlock, PcapLE, _, _>()(i)
 }
 
 #[inline]
 pub fn parse_systemdjournalexportblock_be(
     i: &[u8],
-) -> IResult<&[u8], SystemdJournalExportBlock, PcapError> {
+) -> IResult<&[u8], SystemdJournalExportBlock, PcapError<&[u8]>> {
     ng_block_parser::<SystemdJournalExportBlock, PcapBE, _, _>()(i)
 }
 
 #[inline]
 pub fn parse_decryptionsecretsblock_le(
     i: &[u8],
-) -> IResult<&[u8], DecryptionSecretsBlock, PcapError> {
+) -> IResult<&[u8], DecryptionSecretsBlock, PcapError<&[u8]>> {
     ng_block_parser::<DecryptionSecretsBlock, PcapLE, _, _>()(i)
 }
 
 #[inline]
 pub fn parse_decryptionsecretsblock_be(
     i: &[u8],
-) -> IResult<&[u8], DecryptionSecretsBlock, PcapError> {
+) -> IResult<&[u8], DecryptionSecretsBlock, PcapError<&[u8]>> {
     ng_block_parser::<DecryptionSecretsBlock, PcapBE, _, _>()(i)
 }
 
 #[inline]
-pub fn parse_customblock_le(i: &[u8]) -> IResult<&[u8], CustomBlock, PcapError> {
+pub fn parse_customblock_le(i: &[u8]) -> IResult<&[u8], CustomBlock, PcapError<&[u8]>> {
     ng_block_parser::<CustomBlock, PcapLE, _, _>()(i)
 }
 
 #[inline]
-pub fn parse_customblock_be(i: &[u8]) -> IResult<&[u8], CustomBlock, PcapError> {
+pub fn parse_customblock_be(i: &[u8]) -> IResult<&[u8], CustomBlock, PcapError<&[u8]>> {
     ng_block_parser::<CustomBlock, PcapBE, _, _>()(i)
 }
 
 #[inline]
-pub fn parse_dcb_le(i: &[u8]) -> IResult<&[u8], CustomBlock, PcapError> {
+pub fn parse_dcb_le(i: &[u8]) -> IResult<&[u8], CustomBlock, PcapError<&[u8]>> {
     ng_block_parser::<DCBParser, PcapLE, _, _>()(i)
 }
 
 #[inline]
-pub fn parse_dcb_be(i: &[u8]) -> IResult<&[u8], CustomBlock, PcapError> {
+pub fn parse_dcb_be(i: &[u8]) -> IResult<&[u8], CustomBlock, PcapError<&[u8]>> {
     ng_block_parser::<DCBParser, PcapBE, _, _>()(i)
 }
 
 /// Parse an unknown block (little-endian)
-pub fn parse_unknownblock_le(i: &[u8]) -> IResult<&[u8], UnknownBlock, PcapError> {
+pub fn parse_unknownblock_le(i: &[u8]) -> IResult<&[u8], UnknownBlock, PcapError<&[u8]>> {
     ng_block_parser::<UnknownBlock, PcapLE, _, _>()(i)
 }
 
 /// Parse an unknown block (big-endian)
-pub fn parse_unknownblock_be(i: &[u8]) -> IResult<&[u8], UnknownBlock, PcapError> {
+pub fn parse_unknownblock_be(i: &[u8]) -> IResult<&[u8], UnknownBlock, PcapError<&[u8]>> {
     ng_block_parser::<UnknownBlock, PcapBE, _, _>()(i)
 }
 
@@ -1173,7 +1185,7 @@ pub fn parse_unknownblock_be(i: &[u8]) -> IResult<&[u8], UnknownBlock, PcapError
     note = "This function is deprecated, it does not specify the endianness. Please use the parse_block_le function instead"
 )]
 #[inline]
-pub fn parse_block(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
+pub fn parse_block(i: &[u8]) -> IResult<&[u8], Block, PcapError<&[u8]>> {
     parse_block_le(i)
 }
 
@@ -1181,7 +1193,7 @@ pub fn parse_block(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
 ///
 /// To find which endianess to use, read the section header
 /// using `parse_sectionheaderblock`
-pub fn parse_block_le(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
+pub fn parse_block_le(i: &[u8]) -> IResult<&[u8], Block, PcapError<&[u8]>> {
     match le_u32(i) {
         Ok((_, id)) => match id {
             SHB_MAGIC => map(parse_sectionheaderblock, Block::SectionHeader)(i),
@@ -1213,7 +1225,7 @@ pub fn parse_block_le(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
 ///
 /// To find which endianess to use, read the section header
 /// using `parse_sectionheaderblock`
-pub fn parse_block_be(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
+pub fn parse_block_be(i: &[u8]) -> IResult<&[u8], Block, PcapError<&[u8]>> {
     match be_u32(i) {
         Ok((_, id)) => match id {
             SHB_MAGIC => map(parse_sectionheaderblock, Block::SectionHeader)(i),
@@ -1246,12 +1258,12 @@ pub fn parse_block_be(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
     note = "Please use the parse_section_content_block_le function instead"
 )]
 #[inline]
-pub fn parse_section_content_block(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
+pub fn parse_section_content_block(i: &[u8]) -> IResult<&[u8], Block, PcapError<&[u8]>> {
     parse_section_content_block_le(i)
 }
 
 /// Parse any block from a section (little-endian)
-pub fn parse_section_content_block_le(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
+pub fn parse_section_content_block_le(i: &[u8]) -> IResult<&[u8], Block, PcapError<&[u8]>> {
     let (rem, block) = parse_block_le(i)?;
     match block {
         Block::SectionHeader(_) => Err(Err::Error(make_error(i, ErrorKind::Tag))),
@@ -1260,7 +1272,7 @@ pub fn parse_section_content_block_le(i: &[u8]) -> IResult<&[u8], Block, PcapErr
 }
 
 /// Parse any block from a section (big-endian)
-pub fn parse_section_content_block_be(i: &[u8]) -> IResult<&[u8], Block, PcapError> {
+pub fn parse_section_content_block_be(i: &[u8]) -> IResult<&[u8], Block, PcapError<&[u8]>> {
     let (rem, block) = parse_block_be(i)?;
     match block {
         Block::SectionHeader(_) => Err(Err::Error(make_error(i, ErrorKind::Tag))),
@@ -1269,7 +1281,7 @@ pub fn parse_section_content_block_be(i: &[u8]) -> IResult<&[u8], Block, PcapErr
 }
 
 /// Parse one section (little or big endian)
-pub fn parse_section(i: &[u8]) -> IResult<&[u8], Section, PcapError> {
+pub fn parse_section(i: &[u8]) -> IResult<&[u8], Section, PcapError<&[u8]>> {
     let (rem, shb) = parse_sectionheaderblock(i)?;
     let big_endian = shb.big_endian();
     let (rem, mut b) = if big_endian {
@@ -1286,6 +1298,6 @@ pub fn parse_section(i: &[u8]) -> IResult<&[u8], Section, PcapError> {
 
 /// Parse multiple sections (little or big endian)
 #[inline]
-pub fn parse_sections(i: &[u8]) -> IResult<&[u8], Vec<Section>, PcapError> {
+pub fn parse_sections(i: &[u8]) -> IResult<&[u8], Vec<Section>, PcapError<&[u8]>> {
     many1(complete(parse_section))(i)
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -93,13 +93,15 @@ pub trait PcapNGPacketBlock {
 /// not keep any reference over internal data (blocks or slices), and call `refill`.
 ///
 /// To determine when a refill is needed, either test `next()` for an incomplete read. You can also
-/// use `position` to implement a heuristic refill (for ex, when `positon > capacity / 2`.
+/// use `position` to implement a heuristic refill (for ex, when `position > capacity / 2`.
 ///
 /// **The blocks already read, and underlying data, must be discarded before calling
 /// `consume` or `refill`.** It is the caller's responsibility to call functions in the correct
 /// order.
 pub trait PcapReaderIterator {
     /// Get the next pcap block, if possible. Returns the number of bytes read and the block.
+    ///
+    /// The returned object is valid until `consume` or `refill` is called.
     fn next(&mut self) -> Result<(usize, PcapBlockOwned), PcapError<&[u8]>>;
     /// Consume data, and shift buffer if needed.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -100,7 +100,7 @@ pub trait PcapNGPacketBlock {
 /// order.
 pub trait PcapReaderIterator {
     /// Get the next pcap block, if possible. Returns the number of bytes read and the block.
-    fn next(&mut self) -> Result<(usize, PcapBlockOwned), PcapError>;
+    fn next(&mut self) -> Result<(usize, PcapBlockOwned), PcapError<&[u8]>>;
     /// Consume data, and shift buffer if needed.
     ///
     /// If the position gets past the buffer's half, this will move the remaining data to the
@@ -115,7 +115,7 @@ pub trait PcapReaderIterator {
     ///
     /// **The blocks already read, and underlying data, must be discarded before calling
     /// this function.**
-    fn refill(&mut self) -> Result<(), PcapError>;
+    fn refill(&mut self) -> Result<(), PcapError<&[u8]>>;
     /// Get the position in the internal buffer. Can be used to determine if `refill` is required.
     fn position(&self) -> usize;
     /// Grow size of the internal buffer.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -111,6 +111,8 @@ pub trait PcapReaderIterator {
     fn consume(&mut self, offset: usize);
     /// Consume date, but do not change the buffer. Blocks already read are still valid.
     fn consume_noshift(&mut self, offset: usize);
+    /// Get the number of consumed bytes
+    fn consumed(&self) -> usize;
     /// Refill the internal buffer, shifting it if necessary.
     ///
     /// **The blocks already read, and underlying data, must be discarded before calling

--- a/tests/pcapng.rs
+++ b/tests/pcapng.rs
@@ -59,7 +59,7 @@ fn ng_block_shb_be() {
     assert_eq!(block.major_version, 1);
     assert_eq!(block.minor_version, 0);
     assert_eq!(block.section_len, -1);
-    assert_eq!(block.options.iter().count(), 5);
+    assert_eq!(block.options.len(), 5);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn ng_block_shb_le() {
     assert_eq!(block.major_version, 1);
     assert_eq!(block.minor_version, 0);
     assert_eq!(block.section_len, -1);
-    assert_eq!(block.options.iter().count(), 5);
+    assert_eq!(block.options.len(), 5);
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn ng_block_idb_be() {
     let (i, block) = parse_interfacedescriptionblock_be(input).unwrap();
     assert!(i.is_empty());
     assert_eq!(block.block_type, IDB_MAGIC.swap_bytes());
-    assert_eq!(block.options.iter().count(), 2);
+    assert_eq!(block.options.len(), 2);
     assert_eq!(block.linktype, Linktype(1));
     assert_eq!(block.snaplen, 0);
     assert_eq!(block.if_tsresol, 6);
@@ -94,7 +94,7 @@ fn ng_block_idb_le() {
     let (i, block) = parse_interfacedescriptionblock_le(input).unwrap();
     assert!(i.is_empty());
     assert_eq!(block.block_type, IDB_MAGIC);
-    assert_eq!(block.options.iter().count(), 2);
+    assert_eq!(block.options.len(), 2);
     assert_eq!(block.linktype, Linktype(1));
     assert_eq!(block.snaplen, 0);
     assert_eq!(block.if_tsresol, 6);


### PR DESCRIPTION
Add input to error type (keeping a generic type to 'hide' the lifetime, but using a slice).

This greatly helps debugging by returning a pointer to the input location in the circular buffer on error.