### PR TITLE
Fixed incorrect length calculation for custom blocks.

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -362,7 +362,7 @@ impl<'a> ToVec for CustomBlock<'a> {
             self.block_type = CB_MAGIC;
         }
         // fix length
-        self.block_len1 = (20 + align32!(self.data.len())) as u32;
+        self.block_len1 = (16 + align32!(self.data.len())) as u32;
         self.block_len2 = self.block_len1;
     }
 


### PR DESCRIPTION
The Block Type, PEN and two Block Total Length sections of the the custom block only add up to 16 bytes, not 20.