### PR TITLE
Add support for Apple specific process information blocks

### DIFF
--- a/src/pcapng.rs
+++ b/src/pcapng.rs
@@ -908,6 +908,7 @@ impl<'a> CustomBlock<'a> {
 pub struct ProcessInformationBlock<'a> {
     pub block_type: u32,
     pub block_len1: u32,
+    pub process_id: u32,
     pub options: Vec<PcapNGOption<'a>>,
     pub block_len2: u32,
 }
@@ -926,13 +927,15 @@ impl<'a, En: PcapEndianness> PcapNGBlockParser<'a, En, ProcessInformationBlock<'
     ) -> IResult<&'a [u8], ProcessInformationBlock<'a>, E> {
         // caller function already tested header type(magic) and length
         // read options
-        let (i, options) = opt_parse_options::<En, E>(i, block_len1 as usize, 12)?;
+        let (i, process_id) = En::parse_u32(i)?;
+        let (i, options) = opt_parse_options::<En, E>(i, (block_len1 - 4) as usize, 12)?;
         if block_len2 != block_len1 {
             return Err(Err::Error(E::from_error_kind(i, ErrorKind::Verify)));
         }
         let block = ProcessInformationBlock {
             block_type,
             block_len1,
+            process_id,
             options,
             block_len2,
         };


### PR DESCRIPTION
Hello,

this PR adds support for Apple specific PIB (process information blocks) which contain metadata about the process originating a given packet. These blocks contain some basic info about the processes (process name and command for instance). There is no public documentation about these blocks that I could find but Apple did release their version of `libpcap` which contains some details (see for instance: https://github.com/apple-opensource/libpcap/blob/master/libpcap/pcap/pcap-ng.h#L330).

To test this you will need a Mac and capture packets with the PKTAP interface:
```
sudo tcpdump -i eno1,pktap -w capture.pcap
```