### PR TITLE
Add PcapError::UnexpectedEof error type

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -7,6 +7,7 @@ use crate::pcap::parse_pcap_header;
 use crate::pcapng::parse_sectionheaderblock;
 use crate::traits::PcapReaderIterator;
 use circular::Buffer;
+use nom::Needed;
 use std::io::Read;
 
 /// Generic interface for PCAP or PCAPNG file access
@@ -51,7 +52,8 @@ where
     match parse_pcap_header(buffer.data()) {
         Ok(_) => LegacyPcapReader::from_buffer(buffer, reader)
             .map(|r| Box::new(r) as Box<dyn PcapReaderIterator>),
-        Err(nom::Err::Incomplete(_)) => Err(PcapError::Incomplete),
+        Err(nom::Err::Incomplete(Needed::Size(n))) => Err(PcapError::Incomplete(n.into())),
+        Err(nom::Err::Incomplete(Needed::Unknown)) => Err(PcapError::Incomplete(0)),
         _ => Err(PcapError::HeaderNotRecognized),
     }
 }

--- a/src/capture_pcap.rs
+++ b/src/capture_pcap.rs
@@ -152,7 +152,14 @@ where
                 Ok((offset, PcapBlockOwned::from(b)))
             }
             Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => Err(e),
-            Err(_) => Err(PcapError::Incomplete),
+            Err(nom::Err::Incomplete(_)) => {
+                if self.reader_exhausted {
+                    // expected more bytes but reader is EOF, truncated pcap?
+                    Err(PcapError::UnexpectedEof)
+                } else {
+                    Err(PcapError::Incomplete)
+                }
+            },
         }
     }
     fn consume(&mut self, offset: usize) {

--- a/src/capture_pcapng.rs
+++ b/src/capture_pcapng.rs
@@ -172,7 +172,14 @@ where
                 Ok((offset, PcapBlockOwned::from(b)))
             }
             Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => Err(e),
-            Err(_) => Err(PcapError::Incomplete),
+            Err(nom::Err::Incomplete(_)) => {
+                if self.reader_exhausted {
+                    // expected more bytes but reader is EOF, truncated pcap?
+                    Err(PcapError::UnexpectedEof)
+                } else {
+                    Err(PcapError::Incomplete)
+                }
+            },
         }
     }
     fn consume(&mut self, offset: usize) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub enum PcapError<I: Sized> {
     /// An error happened during a `read` operation
     ReadError,
     /// Last block is incomplete, and no more data available
-    Incomplete,
+    Incomplete(usize),
 
     /// File could not be recognized as Pcap nor Pcap-NG
     HeaderNotRecognized,
@@ -40,7 +40,7 @@ where
             PcapError::Eof => PcapError::Eof,
             PcapError::UnexpectedEof => PcapError::UnexpectedEof,
             PcapError::ReadError => PcapError::ReadError,
-            PcapError::Incomplete => PcapError::Incomplete,
+            PcapError::Incomplete(n) => PcapError::Incomplete(*n),
             PcapError::HeaderNotRecognized => PcapError::HeaderNotRecognized,
             PcapError::NomError(i, errorkind) => {
                 PcapError::OwnedNomError(i.as_ref().to_vec(), *errorkind)
@@ -68,7 +68,7 @@ where
             PcapError::Eof => write!(f, "End of file"),
             PcapError::UnexpectedEof => write!(f, "Unexpected end of file"),
             PcapError::ReadError => write!(f, "Read error"),
-            PcapError::Incomplete => write!(f, "Incomplete read"),
+            PcapError::Incomplete(n) => write!(f, "Incomplete read: {n}"),
             PcapError::HeaderNotRecognized => write!(f, "Header not recognized as PCAP or PCAPNG"),
             PcapError::NomError(i, e) => write!(f, "Internal parser error {:?}, input {:?}", e, i),
             PcapError::OwnedNomError(i, e) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ use std::fmt;
 pub enum PcapError<I: Sized> {
     /// No more data available
     Eof,
+    /// Expected more data but got EOF
+    UnexpectedEof,
     /// An error happened during a `read` operation
     ReadError,
     /// Last block is incomplete, and no more data available
@@ -36,6 +38,7 @@ where
     pub fn to_owned_vec(&self) -> PcapError<&'static [u8]> {
         match self {
             PcapError::Eof => PcapError::Eof,
+            PcapError::UnexpectedEof => PcapError::UnexpectedEof,
             PcapError::ReadError => PcapError::ReadError,
             PcapError::Incomplete => PcapError::Incomplete,
             PcapError::HeaderNotRecognized => PcapError::HeaderNotRecognized,
@@ -63,6 +66,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PcapError::Eof => write!(f, "End of file"),
+            PcapError::UnexpectedEof => write!(f, "Unexpected end of file"),
             PcapError::ReadError => write!(f, "Read error"),
             PcapError::Incomplete => write!(f, "Incomplete read"),
             PcapError::HeaderNotRecognized => write!(f, "Header not recognized as PCAP or PCAPNG"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!             reader.consume(offset);
 //!         },
 //!         Err(PcapError::Eof) => break,
-//!         Err(PcapError::Incomplete) => {
+//!         Err(PcapError::Incomplete(_)) => {
 //!             reader.refill().unwrap();
 //!         },
 //!         Err(e) => panic!("error while reading: {:?}", e),
@@ -118,7 +118,7 @@
 #![deny(unsafe_code)]
 #![allow(clippy::upper_case_acronyms)]
 // pragmas for doc
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(test(
     no_crate_inject,

--- a/tests/pcap.rs
+++ b/tests/pcap.rs
@@ -40,7 +40,7 @@ fn test_pcap_reader() {
                 reader.consume(offset);
             }
             Err(PcapError::Eof) => break,
-            Err(PcapError::Incomplete) => {
+            Err(PcapError::Incomplete(_)) => {
                 reader.refill().unwrap();
             }
             Err(e) => panic!("error while reading: {:?}", e),

--- a/tests/pcapng.rs
+++ b/tests/pcapng.rs
@@ -387,7 +387,7 @@ fn test_pcapng_reader_be() {
                 reader.consume(offset);
             }
             Err(PcapError::Eof) => break,
-            Err(PcapError::Incomplete) => {
+            Err(PcapError::Incomplete(_)) => {
                 reader.refill().unwrap();
             }
             Err(e) => panic!("error while reading: {:?}", e),

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -18,7 +18,7 @@ fn test_empty_reader_incomplete() {
     let res = create_reader(1024, empty);
     assert!(res.is_err());
     if let Err(err) = res {
-        assert_eq!(err, PcapError::Incomplete);
+        assert!(matches!(err, PcapError::Incomplete(_)));
     } else {
         unreachable!();
     }


### PR DESCRIPTION
`pcap_parser` does not currently handle a truncated packet at the end of a pcap file. It will return `PcapError::Incomplete`, which with the given example, will cause an infinite loop. Add an `UnexpectedEof` variant which will be returned when the reader is EOF but nom still wants more data.

Additionally, expose how many more bytes are wanted in `PcapError::Incomplete`.