### PR TITLE
Added const for LINUX_SLL2

### DIFF
--- a/src/linktype.rs
+++ b/src/linktype.rs
@@ -20,6 +20,7 @@ impl display Linktype {
 
     LOOP = 108,
     LINUX_SLL = 113,
+    LINUX_SLL2 = 276,
 
     // Raw IPv4; the packet begins with an IPv4 header.
     IPV4 = 228,


### PR DESCRIPTION
Adds the missing LINUX_SLL2 constant to `linktype.rs`.