### PR TITLE
Replace Circular and Add Miri tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,19 @@ jobs:
       - run: cargo clippy --all-features -- -D warnings
       - run: cargo clippy --no-default-features -- -D warnings
 
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    env:
+      # Needed since the tests interact with the filesystem
+      MIRIFLAGS: "-Zmiri-disable-isolation"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - run: cargo miri test --all-features
+
   doc:
     name: Build documentation
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-circular = "0.3"
+oval = "2.0"
 cookie-factory = { version="0.3.0", optional=true }
 nom = "7.0"
 rusticata-macros = "4.0"
@@ -53,5 +53,5 @@ hex-literal = "0.4"
 allowed_external_types = [
   "nom",
   "nom::*",
-  "circular::Buffer",
+  "oval::Buffer",
 ]

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -5,7 +5,7 @@ use crate::pcap::parse_pcap_header;
 use crate::pcapng::parse_sectionheaderblock;
 use crate::traits::PcapReaderIterator;
 use crate::{LegacyPcapReader, PcapNGReader};
-use circular::Buffer;
+use oval::Buffer;
 use nom::Needed;
 use std::io::Read;
 

--- a/src/pcap/reader.rs
+++ b/src/pcap/reader.rs
@@ -5,7 +5,7 @@ use crate::pcap::{
     LegacyPcapBlock, PcapHeader,
 };
 use crate::traits::PcapReaderIterator;
-use circular::Buffer;
+use oval::Buffer;
 use nom::{IResult, Needed, Offset};
 use std::io::Read;
 

--- a/src/pcapng/reader.rs
+++ b/src/pcapng/reader.rs
@@ -2,7 +2,7 @@ use crate::blocks::PcapBlockOwned;
 use crate::error::PcapError;
 use crate::pcapng::*;
 use crate::traits::PcapReaderIterator;
-use circular::Buffer;
+use oval::Buffer;
 use nom::{Needed, Offset};
 use std::io::Read;
 


### PR DESCRIPTION
 [Oval](https://github.com/fasterthanlime/oval) is a nicer, maintained fork of [Circular](https://github.com/sozu-proxy/circular), that removes the unsafe and unsound code (it [replaces them with stdlib features](https://github.com/fasterthanlime/oval/commit/ce69aed1fff5ee3718e5ec7195c327471cb0a508) that didn't exist at the time of Circular's writing such as copy_within, so it should generate the same code). 
Replacing Ciruclar with Oval means we can now add Miri tests to check for undefined/unsound behavior in unsafe rust (even though there isn't in this crate).