### PR TITLE
Fix PcapNGOption 32 bits conversions

### DIFF
--- a/src/pcapng/option.rs
+++ b/src/pcapng/option.rs
@@ -56,7 +56,7 @@ impl<'a> PcapNGOption<'a> {
     ///
     /// Option data length and declared must be exactly 4 bytes
     pub fn as_i32_le(&self) -> Option<i32> {
-        if self.len == 8 && self.value.len() == 8 {
+        if self.len == 4 && self.value.len() == 4 {
             <[u8; 4]>::try_from(self.value())
                 .ok()
                 .map(i32::from_le_bytes)
@@ -69,7 +69,7 @@ impl<'a> PcapNGOption<'a> {
     ///
     /// Option data length and declared must be exactly 4 bytes
     pub fn as_u32_le(&self) -> Option<u32> {
-        if self.len == 8 && self.value.len() == 8 {
+        if self.len == 4 && self.value.len() == 4 {
             <[u8; 4]>::try_from(self.value())
                 .ok()
                 .map(u32::from_le_bytes)


### PR DESCRIPTION
both `.as_i32_le()` and `.as_u32_le()` in PcapNGOption are expecting 4 bytes. Even though the comments and code is expecting 4 bytes, the checks are incorrectly checking for 8 bytes, causing these 2 functions to return error wrongly. This change fixes the checks so the function behaves correctly.